### PR TITLE
Update turbolinks and image button

### DIFF
--- a/app/assets/javascripts/bootstrap-markdown.js
+++ b/app/assets/javascripts/bootstrap-markdown.js
@@ -1379,7 +1379,7 @@
     .ready(function(){
       initDefaultTextareas()
     })
-    .on('page:load', function(){
+    .on('page:change', function(){
       initDefaultTextareas()
     }) // Turbolinks trigger
     .on('pjax:complete', function(){

--- a/app/assets/javascripts/bootstrap-markdown.js
+++ b/app/assets/javascripts/bootstrap-markdown.js
@@ -1041,7 +1041,7 @@
 
             link = prompt(e.__localize('Insert Image Hyperlink'),'http://')
 
-            if (link != null) {
+            if (link != null && link != '' && link != 'http://') {
               // transform selection and set the cursor into chunked text
               e.replaceSelection('!['+chunk+']('+link+' "'+e.__localize('enter image title here')+'")')
               cursor = selected.start+2


### PR DESCRIPTION
Just tried this over the weekend, and it was nearly perfect for my needs. These two minor changes made it perfect. 

First, the event `page:change` is preferable to `page:load`, because the former is fired when you return to a URL previously loaded, while the latter is not. 

Second, clicking on the image button in the toolbar, but then pressing cancel, causes the placeholder code to be inserted anyway (seen in Safari). This is the same fix as is seen in the link button handler.